### PR TITLE
Setup numpy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.tox
+MANIFEST

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .tox
 MANIFEST
+.cache
+pymangle.egg-info
+pymangle/*pyc

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ MANIFEST
 .cache
 pymangle.egg-info
 pymangle/*pyc
+__pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include README.rts

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include README.rts
+recursive-include pymangle *c *h

--- a/pymangle/mangle.py
+++ b/pymangle/mangle.py
@@ -16,7 +16,7 @@ functions:
 # we also grab the doc strings from the C code as needed, 
 # only writing new ones in the over-ridden methods
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import numpy
 from numpy import array

--- a/pymangle/version.py
+++ b/pymangle/version.py
@@ -3,4 +3,3 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into the module
 __version__ = '0.9.0'
-

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
-from distutils.core import setup, Extension, Command
+import glob
 import os
-import numpy
+
+from setuptools import setup
+from setuptools.extension import Extension
+from setuptools.command import build_ext
 
 
 ext = Extension("pymangle._mangle", ["pymangle/_mangle.c",
@@ -10,8 +13,18 @@ ext = Extension("pymangle._mangle", ["pymangle/_mangle.c",
                                      "pymangle/pixel.c",
                                      "pymangle/point.c",
                                      "pymangle/stack.c",
-                                     "pymangle/rand.c"],
-                include_dirs=[numpy.get_include()])
+                                     "pymangle/rand.c"])
+
+
+class BuildExt(build_ext.build_ext):
+    '''Custom build_ext command to hide the numpy import
+    Inspired by http://stackoverflow.com/a/21621689/1860757'''
+    def finalize_options(self):
+        '''add numpy includes to the include dirs'''
+        build_ext.build_ext.finalize_options(self)
+        import numpy as np
+        self.include_dirs.append(np.get_include())
+        self.include_dirs.extend(glob.glob("pymangle/*h"))
 
 
 exec(open('pymangle/version.py').read())
@@ -35,6 +48,10 @@ setup(name="pymangle",
       long_description=long_description,
       version=__version__,
       license="GPL",
+      install_requires=['numpy', ],
       ext_modules=[ext],
-      include_dirs=numpy.get_include()
+      setup_requires=['numpy', ],
+      cmdclass={'build_ext': BuildExt},
+      include_package_data=True,
+      # include_dirs=numpy.get_include()
       )

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,40 @@
-import distutils
 from distutils.core import setup, Extension, Command
 import os
 import numpy
 
 
-ext=Extension("pymangle._mangle", ["pymangle/_mangle.c",
-                                   "pymangle/mangle.c",
-                                   "pymangle/cap.c",
-                                   "pymangle/polygon.c",
-                                   "pymangle/pixel.c",
-                                   "pymangle/point.c",
-                                   "pymangle/stack.c",
-                                   "pymangle/rand.c"],
-              include_dirs=[numpy.get_include()])
-              
+ext = Extension("pymangle._mangle", ["pymangle/_mangle.c",
+                                     "pymangle/mangle.c",
+                                     "pymangle/cap.c",
+                                     "pymangle/polygon.c",
+                                     "pymangle/pixel.c",
+                                     "pymangle/point.c",
+                                     "pymangle/stack.c",
+                                     "pymangle/rand.c"],
+                include_dirs=[numpy.get_include()])
+
 
 exec(open('pymangle/version.py').read())
 
-description="Simple python code to read and work with Mangle masks."
+description = "Simple python code to read and work with Mangle masks."
 
-dname=os.path.dirname(__file__)
-rstname=os.path.join(dname,'README.rst')
+dname = os.path.dirname(__file__)
+rstname = os.path.join(dname, 'README.rst')
 if os.path.exists(rstname):
-    desc_file=rstname
+    desc_file = rstname
 else:
-    desc_file=os.path.join(dname,'README.md')
+    desc_file = os.path.join(dname, 'README.md')
 
 with open(desc_file) as fobj:
-    long_description=fobj.read()
+    long_description = fobj.read()
 
 
-
-setup(name="pymangle", 
+setup(name="pymangle",
       packages=['pymangle'],
       description=description,
       long_description=long_description,
       version=__version__,
-      license = "GPL",
+      license="GPL",
       ext_modules=[ext],
-      include_dirs=numpy.get_include())
-
-
+      include_dirs=numpy.get_include()
+      )

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,9 @@
+"test that pymangle is correctly imported"
+
+import pymangle
+
+
+def test_Mangle():
+    '''Check that is imported and that the Mangle class exists'''
+    pymangle.Mangle
+    pymangle.__version__

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,12 @@
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py{27,34,35,36}-{np,nonp}
 skip_missing_interpreters = true
+
+[testenv]
+
+deps = 
+    pytest
+    np: numpy
+
+commands = 
+    py.test {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,3 @@
+[tox]
+envlist = py27, py34, py35, py36
+skip_missing_interpreters = true


### PR DESCRIPTION
This PR add ``numpy`` as a build requirements and import it into a custom ``build_ext`` class (I was inspired by [this answer](http://stackoverflow.com/a/21621689/1860757)).

I have also added a tox file that runs tests for python 2.7, 3.4, 3.5 and 3.6 with and without installing ``numpy`` before building ``pymangle``. The test for now is simply to import pymangle and make sure that the ``Mangle`` class and the ``__version__`` can be accessed.

All the tests pass, which means that ``pymangle`` can now build also on systems where numpy is not already installed.