### PR TITLE
Add a pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "pymangle"
+version = "0.9.2"
+description = "\"A python code to read and work with Mangle masks.\""
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.6"
+numpy = "^1.23.4"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-numpy = "^1.23.4"
+numpy = "^1.20.0"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-numpy = "^1.20.0"
+numpy = ">=1.20.0"
 
 
 [build-system]


### PR DESCRIPTION
Since PEP 518 (https://peps.python.org/pep-0518/), python projects should have a toml file. This is required to use modern dependency managers like Poetry (https://python-poetry.org/). This PR adds a pyproject.toml file specifying a numpy dependency, avoiding a circular import. With this PR, you can now install pymangle (and packages which depend on pymangle) using poetry.